### PR TITLE
Updated ValidateSignature

### DIFF
--- a/utils/input/validation.go
+++ b/utils/input/validation.go
@@ -84,13 +84,19 @@ func ValidateAddress(name, value string) (common.Address, error) {
 }
 
 // Validate an EIP-712 signature
-func ValidateSignature(name, signature string) (string, error) {
-	if len(signature) != 132 || signature[:2] != "0x" {
-		return "", fmt.Errorf("Invalid  %s, '%s'\n", name, signature)
+func ValidateEip712Signature(name, value string) ([]byte, error) {
+	// Remove a 0x prefix if present
+	value = strings.TrimPrefix(value, "0x")
+
+	// Try to parse the string
+	signature, err := hex.DecodeString(value)
+	if err != nil {
+		return nil, fmt.Errorf("Invalid %s '%s': %w", name, value, err)
 	}
-	signatureTruncated := signature[2:]
-	if !regexp.MustCompile("^[A-Fa-f0-9]+$").MatchString(signatureTruncated) {
-		return "", fmt.Errorf("Invalid  %s, '%s'\n", name, signature)
+
+	// Signature should be 65 bytes long - see https://github.com/ethereum/EIPs/pull/8722
+	if len(signature) != 65 {
+		return nil, fmt.Errorf("Invalid %s '%s': it must have 65 bytes", name, value)
 	}
 	return signature, nil
 }


### PR DESCRIPTION
Couple changes:

- Rename to `ValidateEip712Signature` since there can be many types of signatures, to prevent naming collision down the line
- Don't require the `0x` prefix, just remove it if present
- Use a conventional hex decoder instead of making your own regex for it
- Verify the byte length after hex decoding, since the decoder's going to do some length checking of its own
- Return a `[]byte` which is the expected output, and is in-line with other validation functions; they all validate an input string and convert it to an expected type instead of leaving the conversion to the caller.
- Rename the input arg to `value` to have parity with the other validation functions 